### PR TITLE
Add 'mozreview.mozops.net' as a route53 hosted zone

### DIFF
--- a/base/outputs.tf
+++ b/base/outputs.tf
@@ -44,3 +44,8 @@ output "bastion_eip" {
 output "autoland_route53_zone_id" {
     value = "${aws_route53_zone.autoland-hz.zone_id}"
 }
+
+# mozreview.mozops.net hosted zone ID
+output "mozops_route53_zone_id" {
+    value = "${aws_route53_zone.mozops_mozreview-hz.zone_id}"
+}

--- a/base/route53.tf
+++ b/base/route53.tf
@@ -1,4 +1,10 @@
-
+# This is a hosted zone delegated from mozilla.org
 resource "aws_route53_zone" "autoland-hz" {
-   name = "autoland.mozilla.org"
+    name = "autoland.mozilla.org"
+}
+
+# This is a hosted zone delegated from mozops.net
+# which is managed under the moz-devservices aws account
+resource "aws_route53_zone" "mozops_mozreview-hz" {
+    name = "mozreview.mozops.net"
 }


### PR DESCRIPTION
    This adds a hosted zone for 'mozreview.mozops.net' where is will be
    delegated from the devservices aws account.  This will allow all
    record management relating to this aws account to be kept within
    this repo.