### PR TITLE
Autoland application load balancer

### DIFF
--- a/autoland-dev/main.tf
+++ b/autoland-dev/main.tf
@@ -11,7 +11,7 @@ module "autoland" {
 
     instance_type = "t2.medium"
     ami_id = "ami-075b9b67"
-    subnets = "172.29.1.0/24"
+    subnets = "172.29.1.0/24,172.29.5.0/24,172.29.6.0/24"
     azs = "${lookup(var.availablity_zones, var.region)}"
 
     rds_subnets = "172.29.2.0/24,172.29.3.0/24,172.29.4.0/24"
@@ -29,6 +29,9 @@ module "autoland" {
 
     user_data_bucket = "${var.base_bucket}"
     addl_user_data = "ssh-pubkeys,associate-eip"
+    ssl_cert_arn = "arn:aws:acm:us-west-2:154007893214:certificate/5a364d17-a006-44e2-b7e8-bd2d73920cb1"
+
+    logging_bucket = "${var.cloudtrail_bucket}"
 }
 
 output "autoland_rds_address" {
@@ -37,5 +40,9 @@ output "autoland_rds_address" {
 
 output "autoland_eip_address" {
     value = "${module.autoland.eip_address}"
+}
+
+output "autoland_alb_dns_name" {
+    value = "${module.autoland.alb_dns_name}"
 }
 

--- a/modules/tf_autoland/alb.tf
+++ b/modules/tf_autoland/alb.tf
@@ -1,0 +1,53 @@
+resource "aws_security_group" "autoland_alb-sg" {
+    name = "${var.env}-autoland-alb-sg"
+    description = "ALB instance security group"
+    vpc_id = "${aws_vpc.autoland_vpc.id}"
+    ingress {
+        from_port = 443
+        to_port = 443
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    egress {
+        from_port = 0
+        to_port = 0
+        protocol = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    tags {
+        Name = "${var.env}-autoland-alb-sg"
+    }
+}
+
+resource "aws_alb" "autoland_alb" {
+    name            = "${var.env}-autoland-alb"
+    internal        = false
+    security_groups = ["${aws_security_group.autoland_alb-sg.id}"]
+    subnets         = ["${aws_subnet.autoland_subnet.*.id}"]
+
+    enable_deletion_protection = true
+
+    access_logs {
+        bucket = "${var.logging_bucket}"
+    }
+}
+
+resource "aws_alb_target_group" "autoland-alb-tg" {
+    name     = "autoland-alb-tg"
+    port     = 80
+    protocol = "HTTP"
+    vpc_id   = "${aws_vpc.autoland_vpc.id}"
+}
+
+resource "aws_alb_listener" "autoland-alb-https-listener" {
+    load_balancer_arn = "${aws_alb.autoland_alb.arn}"
+    port = "443"
+    protocol = "HTTPS"
+    ssl_policy = "ELBSecurityPolicy-2015-05"
+    certificate_arn = "${var.ssl_cert_arn}"
+
+    default_action {
+        target_group_arn = "${aws_alb_target_group.autoland-alb-tg.arn}"
+        type = "forward"
+    }
+}

--- a/modules/tf_autoland/ec2.tf
+++ b/modules/tf_autoland/ec2.tf
@@ -66,8 +66,8 @@ resource "aws_eip" "autoland_web-eip" {
 # Create web head ec2 instances and evenly distribute them across the web subnets/azs
 resource "aws_instance" "web_ec2_instance" {
     ami = "${var.ami_id}"
-    count = "${length(split(",", var.subnets))}"
-    subnet_id = "${element(aws_subnet.autoland_subnet.*.id, count.index % length(split(",", var.subnets)))}"
+    count = 1
+    subnet_id = "${aws_subnet.autoland_subnet.0.id}"
     instance_type = "${var.instance_type}"
     user_data = "${data.template_file.user_data.rendered}"
     vpc_security_group_ids = ["${aws_security_group.autoland_web-sg.id}"]
@@ -91,4 +91,10 @@ resource "aws_instance" "web_ec2_instance" {
         Name = "${var.env}-autoland-${count.index}"
         EIP = "${aws_eip.autoland_web-eip.public_ip}"
     }
+}
+
+resource "aws_alb_target_group_attachment" "autoland_tg_attachment" {
+    target_group_arn = "${aws_alb_target_group.autoland-alb-tg.arn}"
+    target_id = "${aws_instance.web_ec2_instance.id}"
+    port = 80
 }

--- a/modules/tf_autoland/outputs.tf
+++ b/modules/tf_autoland/outputs.tf
@@ -2,7 +2,12 @@
 output "rds_address" {
     value = "${aws_db_instance.autoland-rds.address}"
 }
+
 output "eip_address" {
     value = "${aws_eip.autoland_web-eip.public_ip}"
+}
+
+output "alb_dns_name" {
+    value = "${aws_alb.autoland_alb.dns_name}"
 }
 

--- a/modules/tf_autoland/variables.tf
+++ b/modules/tf_autoland/variables.tf
@@ -65,3 +65,11 @@ variable "user_data_bucket" {
 variable "addl_user_data" {
     description = "List of user-data scripts in user-data bucket for Autoland ec2 instances"
 }
+
+variable "ssl_cert_arn" {
+    description = "SSL Certificate ARN for ALB frontend"
+}
+
+variable "logging_bucket" {
+    description = "S3 bucket for storing logs"
+}


### PR DESCRIPTION
    This adds an application load balancer to the autoland module. The
    SSL Cert must be manually uploaded and the ssl ARN added to be
    passed ot the autoland module.  The EIP can also be removed in a
    latter commit.  This fully offloads the ssl from the ec2 instance
    itself.