### PR TITLE
Allow incoming alb access to be defined

### DIFF
--- a/autoland-dev/main.tf
+++ b/autoland-dev/main.tf
@@ -32,6 +32,8 @@ module "autoland" {
     ssl_cert_arn = "arn:aws:acm:us-west-2:154007893214:certificate/5a364d17-a006-44e2-b7e8-bd2d73920cb1"
 
     logging_bucket = "${var.cloudtrail_bucket}"
+
+    incoming_alb_cidr_blocks = ["0.0.0.0/0"]
 }
 
 # route53 A (Alias) record for autoland ALB

--- a/autoland-prod/main.tf
+++ b/autoland-prod/main.tf
@@ -32,6 +32,8 @@ module "autoland" {
     ssl_cert_arn = "arn:aws:acm:us-west-2:154007893214:certificate/3c52abe9-e69e-4e03-abbc-51c31a723f2f"
 
     logging_bucket = "${var.cloudtrail_bucket}"
+
+    incoming_alb_cidr_blocks = ["0.0.0.0/0"]
 }
 
 # route53 A (Alias) record for autoland.mozilla.org ALB

--- a/modules/tf_autoland/alb.tf
+++ b/modules/tf_autoland/alb.tf
@@ -6,7 +6,7 @@ resource "aws_security_group" "autoland_alb-sg" {
         from_port = 443
         to_port = 443
         protocol = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
+        cidr_blocks = ["${var.incoming_alb_cidr_blocks}"]
     }
     egress {
         from_port = 0

--- a/modules/tf_autoland/variables.tf
+++ b/modules/tf_autoland/variables.tf
@@ -73,3 +73,8 @@ variable "ssl_cert_arn" {
 variable "logging_bucket" {
     description = "S3 bucket for storing logs"
 }
+
+variable "incoming_alb_cidr_blocks" {
+    description = "A list of cidr blocks allowed to access ALB"
+    type = "list"
+}


### PR DESCRIPTION
This allows defining access to the ALB by cidr blocks.  Production will need to be locked down when it comes time to flip over