### PR TITLE
Provide ec2 private ip/dns output in autoland

### DIFF
--- a/autoland-dev/main.tf
+++ b/autoland-dev/main.tf
@@ -84,3 +84,11 @@ output "autoland_mozops_fqdns" {
              "${aws_route53_record.autoland-eip-1_dev_usw2_mozreview_mozops_net.fqdn}",
              "${aws_route53_record.autoland-rds-1_dev_usw2_mozreview_mozops_net.fqdn}"]
 }
+
+output "autoland_ec2_private_dns" {
+    value = "${module.autoland.ec2_private_dns}"
+}
+
+output "autoland_ec2_private_ip" {
+    value = "${module.autoland.ec2_private_ip}"
+}

--- a/autoland-prod/main.tf
+++ b/autoland-prod/main.tf
@@ -98,3 +98,10 @@ output "autoland_mozops_fqdns" {
              "${aws_route53_record.autoland-rds-1_usw2_mozreview_mozops_net.fqdn}"]
 }
 
+output "autoland_ec2_private_dns" {
+    value = "${module.autoland.ec2_private_dns}"
+}
+
+output "autoland_ec2_private_ip" {
+    value = "${module.autoland.ec2_private_ip}"
+}

--- a/modules/tf_autoland/outputs.tf
+++ b/modules/tf_autoland/outputs.tf
@@ -14,3 +14,11 @@ output "alb_dns_name" {
 output "alb_zone_id" {
     value = "${aws_alb.autoland_alb.zone_id}"
 }
+
+output "ec2_private_dns" {
+    value = "${aws_instance.web_ec2_instance.private_dns}"
+}
+
+output "ec2_private_ip" {
+    value = "${aws_instance.web_ec2_instance.private_ip}"
+}


### PR DESCRIPTION
    Since the eip is obsolete (and may be removed in the future) we
    need to provide output for the private dns and ip.  This is useful
    for setting up ssh config entries to be properly proxied through the
    bastion host.